### PR TITLE
Add ui.slash enum option

### DIFF
--- a/cli/src/cli_util.rs
+++ b/cli/src/cli_util.rs
@@ -98,7 +98,7 @@ use jj_lib::repo::StoreFactories;
 use jj_lib::repo::StoreLoadError;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
-use jj_lib::repo_path::RepoPathUiConverter;
+use jj_lib::repo_path::{RepoPathUiConverter, SlashChoice};
 use jj_lib::repo_path::UiPathParseError;
 use jj_lib::revset;
 use jj_lib::revset::ResolvedRevsetExpression;
@@ -800,6 +800,7 @@ impl WorkspaceCommandEnvironment {
         let path_converter = RepoPathUiConverter::Fs {
             cwd: command.cwd().to_owned(),
             base: workspace.workspace_root().to_owned(),
+            slash: settings.get("ui.slash")?,
         };
         let mut env = Self {
             command: command.clone(),
@@ -1366,6 +1367,7 @@ to the current parents may contain changes from multiple commits.
             &RepoPathUiConverter::Fs {
                 cwd: "".into(),
                 base: "".into(),
+                slash: SlashChoice::Native,
             },
         )?;
         print_parse_diagnostics(ui, "In `snapshot.auto-track`", &diagnostics)?;

--- a/cli/src/commands/fix.rs
+++ b/cli/src/commands/fix.rs
@@ -29,7 +29,7 @@ use jj_lib::fix::FileToFix;
 use jj_lib::fix::FixError;
 use jj_lib::fix::ParallelFileFixer;
 use jj_lib::matchers::Matcher;
-use jj_lib::repo_path::RepoPathUiConverter;
+use jj_lib::repo_path::{RepoPathUiConverter, SlashChoice};
 use jj_lib::settings::UserSettings;
 use jj_lib::store::Store;
 use pollster::FutureExt as _;
@@ -319,6 +319,7 @@ fn get_tools_config(ui: &mut Ui, settings: &UserSettings) -> Result<ToolsConfig,
                             &RepoPathUiConverter::Fs {
                                 cwd: "".into(),
                                 base: "".into(),
+                                slash: SlashChoice::Native,
                             },
                         )
                     })

--- a/cli/src/commit_templater.rs
+++ b/cli/src/commit_templater.rs
@@ -53,6 +53,8 @@ use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::repo_path::RepoPathUiConverter;
+#[cfg(test)]
+use jj_lib::repo_path::SlashChoice;
 use jj_lib::revset;
 use jj_lib::revset::Revset;
 use jj_lib::revset::RevsetContainingFn;
@@ -2423,6 +2425,7 @@ mod tests {
             let path_converter = RepoPathUiConverter::Fs {
                 cwd: test_workspace.workspace.workspace_root().to_owned(),
                 base: test_workspace.workspace.workspace_root().to_owned(),
+                slash: SlashChoice::Native,
             };
             // IdPrefixContext::new() expects Arc<RevsetExtensions>
             #[expect(clippy::arc_with_non_send_sync)]
@@ -2444,6 +2447,7 @@ mod tests {
             self.path_converter = RepoPathUiConverter::Fs {
                 cwd: self.test_workspace.workspace.workspace_root().join(path),
                 base: self.test_workspace.workspace.workspace_root().to_owned(),
+                slash: SlashChoice::Native,
             };
         }
 

--- a/cli/src/config-schema.json
+++ b/cli/src/config-schema.json
@@ -105,6 +105,12 @@
                     ],
                     "default": "auto"
                 },
+                "slash": {
+                    "type": "string",
+                    "description": "Path separator style for displayed paths",
+                    "enum": ["native", "unix", "windows"],
+                    "default": "native"
+                },
                 "paginate": {
                     "type": "string",
                     "description": "Whether or not to use a pager",

--- a/cli/src/config/misc.toml
+++ b/cli/src/config/misc.toml
@@ -33,6 +33,8 @@ quiet = false
 log-word-wrap = false
 log-synthetic-elided-nodes = true
 conflict-marker-style = "diff"
+# Path separator style
+slash = "native"
 # signature verification is slow, disable by default
 show-cryptographic-signatures = false
 bookmark-list-sort-keys = ["name"]

--- a/cli/src/merge_tools/mod.rs
+++ b/cli/src/merge_tools/mod.rs
@@ -39,6 +39,8 @@ use jj_lib::repo_path::InvalidRepoPathError;
 use jj_lib::repo_path::RepoPath;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::repo_path::RepoPathUiConverter;
+#[cfg(test)]
+use jj_lib::repo_path::SlashChoice;
 use jj_lib::settings::UserSettings;
 use jj_lib::working_copy::SnapshotError;
 use pollster::FutureExt as _;
@@ -772,6 +774,7 @@ mod tests {
             let path_converter = RepoPathUiConverter::Fs {
                 cwd: "".into(),
                 base: "".into(),
+                slash: SlashChoice::Native,
             };
             MergeEditor::with_name(name, &settings, path_converter, ConflictMarkerStyle::Diff)
                 .map(|editor| editor.tool)
@@ -832,6 +835,7 @@ mod tests {
             let path_converter = RepoPathUiConverter::Fs {
                 cwd: "".into(),
                 base: "".into(),
+                slash: SlashChoice::Native,
             };
             MergeEditor::from_settings(&ui, &settings, path_converter, ConflictMarkerStyle::Diff)
                 .map(|editor| editor.tool)

--- a/docs/config.md
+++ b/docs/config.md
@@ -401,6 +401,21 @@ conflict-marker-style = "git"
 For more details about these conflict marker styles, see the [conflicts
 page](conflicts.md#conflict-markers).
 
+### Path separator style
+
+By default, paths in jj's output use the platform-specific separator. Set
+`ui.slash` to control how separators are shown:
+
+```toml
+[ui]
+# use the OS default
+slash = "native"
+# force Unix-style separators
+# slash = "unix"
+# force Windows-style separators
+# slash = "windows"
+```
+
 ### Set of immutable commits
 
 You can configure the set of immutable commits via

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -6,6 +6,7 @@ user.email = "YOUR_EMAIL@example.com"
 
 ui.color = "auto" # the default
 # ui.color = never # no color
+ui.slash = "native" # path separator style (native/unix/windows)
 
 ui.editor = "pico" # the default on Unix
 # ui.editor = "vim"

--- a/lib/src/fileset.rs
+++ b/lib/src/fileset.rs
@@ -47,6 +47,8 @@ use crate::repo_path::RelativePathParseError;
 use crate::repo_path::RepoPath;
 use crate::repo_path::RepoPathBuf;
 use crate::repo_path::RepoPathUiConverter;
+#[cfg(test)]
+use crate::repo_path::SlashChoice;
 use crate::repo_path::UiPathParseError;
 
 /// Error occurred during file pattern parsing.
@@ -528,6 +530,7 @@ mod tests {
         let path_converter = RepoPathUiConverter::Fs {
             cwd: PathBuf::from("/ws/cur"),
             base: PathBuf::from("/ws"),
+            slash: SlashChoice::Native,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
@@ -573,6 +576,7 @@ mod tests {
             // meta character in cwd path shouldn't be expanded
             cwd: PathBuf::from("/ws/cur*"),
             base: PathBuf::from("/ws"),
+            slash: SlashChoice::Native,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
@@ -746,6 +750,7 @@ mod tests {
         let path_converter = RepoPathUiConverter::Fs {
             cwd: PathBuf::from("/ws/cur"),
             base: PathBuf::from("/ws"),
+            slash: SlashChoice::Native,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 
@@ -774,6 +779,7 @@ mod tests {
         let path_converter = RepoPathUiConverter::Fs {
             cwd: PathBuf::from("/ws/cur"),
             base: PathBuf::from("/ws"),
+            slash: SlashChoice::Native,
         };
         let parse = |text| parse_maybe_bare(&mut FilesetDiagnostics::new(), text, &path_converter);
 

--- a/lib/src/revset.rs
+++ b/lib/src/revset.rs
@@ -54,6 +54,8 @@ use crate::repo::ReadonlyRepo;
 use crate::repo::Repo;
 use crate::repo::RepoLoaderError;
 use crate::repo_path::RepoPathUiConverter;
+#[cfg(test)]
+use crate::repo_path::SlashChoice;
 use crate::revset_parser;
 pub use crate::revset_parser::expect_literal;
 pub use crate::revset_parser::parse_program;
@@ -3162,6 +3164,7 @@ mod tests {
         let path_converter = RepoPathUiConverter::Fs {
             cwd: PathBuf::from("/"),
             base: PathBuf::from("/"),
+            slash: SlashChoice::Native,
         };
         let workspace_ctx = RevsetWorkspaceContext {
             path_converter: &path_converter,

--- a/lib/tests/test_revset.rs
+++ b/lib/tests/test_revset.rs
@@ -41,7 +41,7 @@ use jj_lib::ref_name::WorkspaceName;
 use jj_lib::ref_name::WorkspaceNameBuf;
 use jj_lib::repo::Repo;
 use jj_lib::repo_path::RepoPath;
-use jj_lib::repo_path::RepoPathUiConverter;
+use jj_lib::repo_path::{RepoPathUiConverter, SlashChoice};
 use jj_lib::revset::parse;
 use jj_lib::revset::DefaultSymbolResolver;
 use jj_lib::revset::FailingSymbolResolver;
@@ -946,6 +946,7 @@ fn resolve_commit_ids_in_workspace(
     let path_converter = RepoPathUiConverter::Fs {
         cwd: cwd.unwrap_or_else(|| workspace.workspace_root()).to_owned(),
         base: workspace.workspace_root().to_owned(),
+        slash: SlashChoice::Native,
     };
     let workspace_ctx = RevsetWorkspaceContext {
         path_converter: &path_converter,


### PR DESCRIPTION
## Summary
- implement `SlashChoice` enum with `native`, `unix`, and `windows`
- use the enum in `RepoPathUiConverter` and update tests
- document new values in config docs and schema
- update default config to use `ui.slash = "native"`

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68552375393c832b84a6849f3375f795